### PR TITLE
Fix overflow in floating point multiplication

### DIFF
--- a/src/ta_func/ta_MULT.c
+++ b/src/ta_func/ta_MULT.c
@@ -255,7 +255,7 @@
 /* Generated */ #else
 /* Generated */       for( i=startIdx, outIdx=0; i <= endIdx; i++, outIdx++ )
 /* Generated */       {
-/* Generated */          outReal[outIdx] = inReal0[i]*inReal1[i];
+/* Generated */          outReal[outIdx] = ((double)inReal0[i])*inReal1[i];
 /* Generated */       }    
 /* Generated */ #endif
 /* Generated */    VALUE_HANDLE_DEREF(outNBElement) = outIdx;


### PR DESCRIPTION
At least a potential one.

I doubt this is acceptable, since it should be fixed in the code generator.
The file has not been updated for 11  years, so this may be suitable.
Please, let me know, I may be able to fix it in the generator.